### PR TITLE
Support --name options to filter spec files + use patched Jest clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,16 @@ module.exports = function (options) {
     options = options || {};
     return through.obj(function (file, enc, cb) {
         options.rootDir = options.rootDir || file.path;
-        jest.runCLI({
-            config: options
-        }, options.rootDir, function (success) {
+
+        var cliOptions = {config: options};
+        for(var i = 0, j = process.argv.length; i < j; i++) {
+            if(process.argv[i].indexOf('--name=') === 0) {
+                var value = process.argv[i].substring('--name='.length);
+                cliOptions.testPathPattern = new RegExp(value);
+            }
+        }
+
+        jest.runCLI(cliOptions, options.rootDir, function (success) {
             if(!success) {
                 cb(new gutil.PluginError('gulp-jest', { message: "Tests Failed" }));
             } else {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Dakuan/gulp-jest",
   "dependencies": {
-    "jest-cli": "^0.4.0",
+    "jest-cli": "git+https://github.com/m6web/jest.git#v0.5.0",
     "gulp-util": "^3.0.0",
     "through2": "^0.5.1",
     "react-tools": "^0.12.1"


### PR DESCRIPTION
- Add a --name options. gulp-jest doesn't support CLI Jest options. See https://github.com/Dakuan/gulp-jest/issues/7 . We need to make a proper PR (this one is only here to fit ours needs).
- Use patched version of Jest, see https://github.com/M6Web/jest/pull/1
